### PR TITLE
docs: RPi5 NVMe storage node migration runbook + partition-aware cleanup-nvme.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,9 @@ export GITHUB_TOKEN=<your-personal-access-token>
 
 Storage nodes booting from onboard NVMe are provisioned with a dedicated raw partition
 for rook-ceph. See [docs/rpi5-nvme-storage-node.md](docs/rpi5-nvme-storage-node.md) for
-the migration runbook and [scripts/cleanup-nvme.sh](scripts/cleanup-nvme.sh) (which only
-wipes the rook partition when the OS runs from the same disk).
+the migration runbook — including the golden-image flow used to set up the remaining
+nodes — and [scripts/cleanup-nvme.sh](scripts/cleanup-nvme.sh) (wipes the rook-ceph
+partition, `/dev/nvme0n1p3` by default; no checks, the caller provides the target device).
 
 ### Add worker node to a existing Talos cluster
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ export GITHUB_TOKEN=<your-personal-access-token>
 ./bootstrap.sh
 ```
 
+### Raspberry Pi 5 NVMe storage nodes
+
+Storage nodes booting from onboard NVMe are provisioned with a dedicated raw partition
+for rook-ceph. See [docs/rpi5-nvme-storage-node.md](docs/rpi5-nvme-storage-node.md) for
+the migration runbook and [scripts/cleanup-nvme.sh](scripts/cleanup-nvme.sh) (which only
+wipes the rook partition when the OS runs from the same disk).
+
 ### Add worker node to a existing Talos cluster
 
 Generate the Kubernetes configuration files from the Talos control-plane and copy them to the target node:

--- a/docs/rpi5-nvme-storage-node.md
+++ b/docs/rpi5-nvme-storage-node.md
@@ -155,14 +155,22 @@ grow.)
 ### Step 6 — Per-node configuration into the NVMe boot partition
 
 The freshly written image has no hostname/user/networking customization. Copy the
-customized files from the staging SD's boot partition onto the NVMe's `p1` (the tutorial
-does the same), then edit them for this node:
+customized `user-data`/`network-config` files from the staging SD's boot partition onto
+the NVMe's `p1` (the tutorial does the same), then edit them for this node:
 
 ```bash
 sudo mkdir /mnt/nvfat
 sudo mount /dev/nvme0n1p1 /mnt/nvfat
-sudo cp /boot/firmware/cmdline.txt /boot/firmware/user-data /boot/firmware/network-config /mnt/nvfat/
+sudo cp /boot/firmware/user-data /boot/firmware/network-config /mnt/nvfat/
 ```
+
+**Do not copy `cmdline.txt`.** rpi-imager stamps every write with a fresh, randomized
+disk signature, and the NVMe's own `cmdline.txt` (written in Step 4) already has the
+`root=PARTUUID=...` matching *its own* `p2`. The staging SD's `cmdline.txt` encodes the
+SD's PARTUUID instead — copying it over would point the NVMe's root= at a partition that
+no longer exists once the SD is removed, and the node would fail to boot. Leave the
+NVMe's `cmdline.txt` as rpi-imager wrote it; Step 8 appends the required boot parameters
+to it in place.
 
 Edit the copies on the mounted `p1`:
 
@@ -244,7 +252,9 @@ Precondition: the companion PR in `mmontes11/k8s-infrastructure`, which switches
 `infrastructure/rook/rook-ceph-cluster/rook-ceph-cluster-helmrelease.yaml`, **is merged and
 applied by Flux** before this step.
 
-1. Remove the old OSD from the cluster (its data was wiped in Step 4):
+1. Remove the old OSD from the cluster (its data was wiped in Step 4). Substitute `3`
+   below with the OSD id you noted for this node in Step 1 (`osd-3` on `storage-2` at
+   the time of writing — it will differ for `storage-1`/`storage-0`):
 
    ```bash
    kubectl -n storage exec deploy/rook-ceph-tools -- ceph osd out 3

--- a/docs/rpi5-nvme-storage-node.md
+++ b/docs/rpi5-nvme-storage-node.md
@@ -1,58 +1,73 @@
 # Raspberry Pi 5 storage node: SD card to NVMe migration
 
-Migrates a Raspberry Pi 5 worker/storage node from an SD-card root filesystem to the onboard
-NVMe module, so the OS lives on fast, durable storage while keeping a dedicated raw
-partition for the [rook-ceph](https://rook.io/) OSD.
+Migrates a Raspberry Pi 5 worker/storage node from an SD-card root filesystem to the 2TB
+onboard NVMe module, so the OS lives on fast, durable storage while keeping a dedicated raw
+partition for the [rook-ceph](https://rook.io/) OSD. After the first node is migrated, its
+disk is captured as a byte-for-byte golden image and `dd`'d onto the remaining nodes.
 
-Reference: [Install Ubuntu on the NVMe of a Raspberry Pi 5](https://wolfpaulus.com/rp5-ubuntu-cli/).
+No second Linux machine or USB NVMe enclosure is needed: a freshly flashed microSD card
+boots every node as the staging OS, and the NVMe image/partition work is done from there —
+the same flow as the
+[reference tutorial](https://wolfpaulus.com/rp5-ubuntu-cli/).
 
-## Target layout
+## Target layout (2TB NVMe module)
 
-A 128GB NVMe module, 3 partitions (the RPi5 firmware requires a FAT32 `/boot/firmware`
-partition, hence one more partition than a plain Linux install):
+3 partitions. The RPi5 firmware requires a FAT32 `/boot/firmware` partition on the boot
+device, hence one more partition than a plain Linux install:
 
-| Partition | Filesystem | Size   | Mount  |
-|-----------|------------|--------|--------|
-| `nvme0n1p1` | fat32    | 512MiB | `/boot/firmware` |
-| `nvme0n1p2` | ext4     | ~124GiB | `/` |
-| `nvme0n1p3` | (raw, unformatted) | remainder (~4GiB) | none — claimed by rook-ceph |
+| Partition  | Filesystem             | Size                        | Mount                |
+|------------|------------------------|-----------------------------|----------------------|
+| `nvme0n1p1` | fat32                 | 512MiB                      | `/boot/firmware`     |
+| `nvme0n1p2` | ext4                  | ends at `128GiB` (fs `124G`) | `/`                  |
+| `nvme0n1p3` | (raw, unformatted)    | remainder (~1.7TiB)         | none — claimed by rook-ceph |
 
 Rook consumes `nvme0n1p3`. The OS never sees `nvme0n1p3`; rook takes exclusive control of
 it, exactly as it does today with the whole-disk `nvme0n1` configuration on the other nodes.
 
+The split is controlled by one number, `OS_END` (`128GiB` below). If you want a different
+OS/OSD split, change it consistently in Steps 5 and 6 — nowhere else.
+
 ## Safety rules (read first)
 
-1. **One node at a time.** Never migrate two storage nodes in parallel.
-2. **Ceph must be `HEALTH_OK` before you start.** Check on the control plane:
+1. **One node at a time.** Never migrate two storage nodes in parallel: the cluster must
+   never be short two OSDs at once.
+2. **One down OSD is tolerated, a *stacked* degradation is not.** With three OSDs and
+   `size(ceph_osd_pool) = 3`, a node being offline leaves two working OSDs: `min_size` is
+   satisfied, I/O continues, and Ceph shows `HEALTH_WARN` with degraded PGs for the offline
+   window. That is expected and acceptable. What is **not** acceptable is starting the
+   migration while the cluster is *already* degraded or converging (missing OSD, or
+   `active+undersized+...+backfilling` PGs from a previous event) — that stacks a second
+   degradation and can leave the cluster unrecoverable. Check on the control plane:
+
    ```bash
    kubectl -n storage exec deploy/rook-ceph-tools -- ceph -s
    ```
-   If there is an in-flight backfill (e.g. `active+undersized+degraded+...+backfilling`
-   PGs after a previous re-image), wait until all PGs are `active+clean`. Migrating a node
-   while the cluster is already degraded compounds the degraded window and can leave the
-   cluster in a state it cannot recover.
+
 3. **Keep the original SD card until the node is fully back in service** (see
-   [Rollback](#rollback). It is your safety net and your spare for the next node.
+   [Rollback](#rollback)). It is your safety net.
 4. **Merge the rook device-config PR before the migrated node rejoins the cluster** (see
-   [Step 7](#step-7-rook-osd-migration)). Otherwise rook still expects the old
-   whole-disk `nvme0n1` and will never see `nvme0n1p3`.
-5. The OS partition is sized to leave only ~4GiB for the OSD. Raise `OS_END` (and lower the
-   OSD) or lower it (and grow the OSD) to taste — but decide before flashing, the numbers
-   below are used consistently.
+   [Step 10](#step-10-rook-osd-migration)). Otherwise rook still expects the old whole-disk
+   `nvme0n1` and will never see `nvme0n1p3`.
+5. **The golden image is only valid while `nvme0n1p3` is raw** — captured *before* the node
+   first boots (Step 7), so no OSD metadata exists on it yet. Never re-capture the disk
+   after the node has rejoined and rook has created the new OSD.
 
 ## Tools and hardware
 
-- A second Linux machine (the "helper") with a USB NVMe enclosure, plus: `rpi-imager`,
-  `parted`, `sgdisk`, `e2fsck`, `resize2fs` (the `ubuntu-image` + `parted` +
-  `dosfstools` + `e2fsprogs` packages).
-- Ubuntu 24.04 preinstalled server image for Raspberry Pi
+- The node's own hardware: a **fresh ≥16GB microSD card** (the "staging OS" medium, reused
+  per node) and the node's **original SD card** (kept untouched for rollback).
+- A USB stick to hold the golden image: the `dd` copy is 2TB *apparent* size but with
+  `conv=sparse` it consumes only a few GB of real data (a fresh OS install plus an empty
+  partition), so a 16GB stick is plenty.
+- The Ubuntu 24.04 preinstalled server image for Raspberry Pi
   (`ubuntu-24.04.4-preinstalled-server-arm64+raspi.img.xz` from the
   [Ubuntu releases](https://cdimage.ubuntu.com/releases/24.04/release/) archive, or via
   rpi-imager's built-in catalog).
-- A USB-serial console for the Pi (the storage nodes have no display; you need the console
-  to boot into a fresh install and set the hostname/network).
+- rpi-imager on whatever machine you already use to image SD cards.
+- Once the staging OS is booted on the Pi: `sudo apt update && sudo apt install -y
+  rpi-imager parted gdisk` (`e2fsprogs` ships with the base image).
 
-## Procedure
+## Migrating the first node (storage-2) — produces the golden image
 
 ### Step 1 — Pre-flight on the control plane
 
@@ -62,126 +77,169 @@ kubectl get nodes -l node.mmontes.io/type=storage
 kubectl -n storage get pods -l app=rook-ceph-osd -o wide    # note which osd pod runs on the target node
 ```
 
-Note the OSD id of the target node (e.g. `osd-3` on `storage-2`). You need it for
-[Step 7](#step-7-rook-osd-migration). Ceph must say `HEALTH_OK` — see safety rules.
+Per safety rule 2: the cluster must be converged (no missing OSDs, no in-flight
+backfills). Note the OSD id of the target node (e.g. `osd-3` on `storage-2`) — you need it
+in [Step 10](#step-10-rook-osd-migration).
 
 ### Step 2 — Take the node out of the cluster
 
 On the control plane:
 
 ```bash
-kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
+kubectl drain storage-2 --ignore-daemonsets --delete-emptydir-data
 ```
 
-Then power the Pi off and remove its NVMe module into the USB enclosure on the helper.
+Then power the Pi off. Its OSD is now down; the cluster runs on the remaining two OSDs
+(expected — see safety rule 2).
 
-### Step 3 — Flash a fresh OS onto the NVMe
+### Step 3 — Boot the staging OS from a fresh SD card
 
-From the helper:
+Image the fresh SD card with rpi-imager as you would any node (customize hostname — e.g.
+`rpi5-stage` — a reachable IP and your SSH key). Insert it into the powered-off Pi, power
+on, and SSH in.
 
 ```bash
-# Identify the raw device (lsblk). Assume /dev/nvme0n1 on the helper for the commands below.
-sudo rpi-imager
+sudo apt update && sudo apt install -y rpi-imager parted gdisk
+lsblk -f      # the NVMe must be visible; it still holds the old OSD's data
 ```
 
-In rpi-imager: OS → *Ubuntu 24.04 (preinstalled, Raspberry Pi)*, Storage → the NVMe device,
-flash. This writes a two-partition GPT: `p1` FAT32 (boot) and `p2` ext4 (root, sized for
-the image, not for the disk).
+The staging OS lives on `mmcblk0`; the NVMe (`/dev/nvme0n1`) is unused and unmounted by it,
+so everything done to it in the next steps is safe.
 
-### Step 4 — Offline partition surgery (helper, NVMe not booted)
+### Step 4 — Write the OS image onto the NVMe
 
-Goal: shrink/fit `p2` to end at `124GiB`, grow its ext4 to `120G`, and create the raw
-rook partition `p3` from what is left. Everything here is safe because **the disk is not
-being used by any running system**.
+On the staging OS (the same image that was written to the SD card):
 
 ```bash
-DEV=/dev/nvme0n1    # the flashed NVMe on the helper — verify with lsblk
+wget https://cdimage.ubuntu.com/releases/24.04.4/release/ubuntu-24.04.4-preinstalled-server-arm64+raspi.img.xz
+sudo rpi-imager --cli ubuntu-24.04.4-preinstalled-server-arm64+raspi.img.xz /dev/nvme0n1
+```
 
-sudo parted -s $DEV print                       # sanity check: GPT, p1 fat, p2 ext4
+Double-check the target device with `lsblk` before running rpi-imager — it writes the
+second argument, and this step **wipes the old OSD data on `nvme0n1`**. That is intended
+(the OSD was drained with the node; it is formally removed in Step 10).
 
-# Fit p2: extend (or trim) its end boundary to 124GiB from the start of the disk.
-sudo parted -s $DEV resizepart 2 124GiB
+The result is a two-partition GPT: `p1` FAT32 (boot), `p2` ext4 (root, sized for the image,
+i.e. a few GiB — not the full disk).
 
-# Check/ext4 before touching it (-f forces, -y answers yes to cleanups):
-sudo e2fsck -f -y ${DEV}p2
+### Step 5 — Partition surgery (NVMe still offline)
 
-# Set the ext4 to 120G. resize2fs both grows and shrinks to the requested size, so this
-# one command covers whether p2 was image-sized or already expanded to the full disk.
-sudo resize2fs ${DEV}p2 120G
+Fit `p2` to end at `128GiB`, set its ext4 to `124G`, then create the raw rook partition
+`p3` from what is left:
+
+```bash
+DEV=/dev/nvme0n1
+
+sudo parted -s $DEV print                        # sanity check: GPT, p1 fat, p2 ext4 (small)
+sudo parted -s $DEV resizepart 2 128GiB          # grow p2's end boundary to 128GiB from the start of the disk
+sudo e2fsck -f ${DEV}p2                          # check before/during resize
+sudo resize2fs ${DEV}p2 124G                     # grow the fs to 124G inside the 128GiB partition
 
 # Create the rook partition from the remainder of the disk. Do NOT format it:
-sudo parted -s $DEV mkpart rook 124GiB 100%
-sudo sgdisk -t 3:8300 $DEV                      # explicit Linux filesystem partition type
+sudo parted -s $DEV mkpart rook 128GiB 100%
+sudo sgdisk -t 3:8300 $DEV                       # explicit "Linux filesystem" partition type
 
 # Verify:
 sudo parted -s $DEV print
-sudo blkid ${DEV}p2 ${DEV}p3                    # p2 must show ext4; p3 must show NOTHING
+sudo blkid ${DEV}p2 ${DEV}p3                     # p2 must show ext4; p3 must show NOTHING
 ```
 
 `blkid` printing nothing for `p3` is required: rook provisions an unformatted device
-itself. If `blkid` reports a filesystem on `p3`, delete and recreate the partition.
+itself. (If for some reason `p2` is *larger* than `128GiB` instead of smaller, shrink first
+in the order `e2fsck -f -y` → `resize2fs 124G` → `resizepart`; the commands above only
+grow.)
 
-### Step 5 — First NVMe boot on the Pi
+### Step 6 — Per-node configuration into the NVMe boot partition
 
-Reinstall the NVMe, **leave the SD card out**, power on, and follow the console:
+The freshly written image has no hostname/user/networking customization. Copy the
+customized files from the staging SD's boot partition onto the NVMe's `p1` (the tutorial
+does the same), then edit them for this node:
 
-- Set the hostname (e.g. `storage-0`) and the static IP matching your inventory.
-- The preinstalled image runs cloud-init on first boot. After login, verify the layout is
-  intact (cloud-init must not have expanded `p2` beyond the boundary):
+```bash
+sudo mkdir /mnt/nvfat
+sudo mount /dev/nvme0n1p1 /mnt/nvfat
+sudo cp /boot/firmware/cmdline.txt /boot/firmware/user-data /boot/firmware/network-config /mnt/nvfat/
+```
 
-  ```bash
-  lsblk /dev/nvme0n1
-  df -h /
-  blkid /dev/nvme0n1p3     # must print nothing
-  ```
+Edit the copies on the mounted `p1`:
 
-  `p2` must be ~124G and mounted on `/`, and `p3` unmounted. If `p2` grew over the
-  boundary (p3 gone or shrunk), stop: power off, redo [Step 4](#step-4--offline-partition-surgery-helper-nvme-not-booted)
-  on the helper. Booting from the original SD card is the fallback (see Rollback).
+- `user-data`: `hostname:` must be the **node name** (`storage-2`) — the node will be
+  re-joined under that name.
+- `network-config` / netplan section: the node's address, exactly as it was before.
 
-Then run the standard node preparation (works unchanged, `cmdline.txt` now lives on the
-NVMe `p1`):
+```bash
+sudo umount /mnt/nvfat
+```
+
+### Step 7 — Capture the golden image (before first boot, `p3` still raw)
+
+Back up the fully partitioned, not-yet-booted disk to the USB stick:
+
+```bash
+# /dev/sdc = the USB stick — verify with lsblk so you never write to the NVMe
+sudo dd if=/dev/nvme0n1 of=/dev/sdc/rpi5-nvme-golden.img bs=4M conv=sparse status=progress
+sync
+```
+
+The file is 2TB in apparent size but `conv=sparse` stores only the non-zero bytes (a few GB
+for a fresh install); the read of the empty partition dominates the runtime (order of an
+hour). Keep a copy of this image safe — it sets up the remaining nodes.
+
+### Step 8 — First NVMe boot
+
+Shut down the staging OS, **remove the SD card**, power on. The firmware tries the SD slot
+first, finds nothing, and boots the NVMe.
+
+SSH in and verify the layout is intact (first-boot auto-grow only extends the filesystem
+*within* `p2`'s end boundary, so `p3` is safe, but confirm):
+
+```bash
+lsblk /dev/nvme0n1
+df -h /                    # / ≈ 124G, on nvme0n1p2
+blkid /dev/nvme0n1p3       # must print nothing
+hostnamectl                 # must be storage-2
+```
+
+If anything looks wrong, stop and roll back (SD card). Otherwise run the standard node
+preparation (works unchanged — `cmdline.txt` now lives on the NVMe `p1`):
 
 ```bash
 sudo bash node-prepare.sh
 sudo reboot
 ```
 
-### Step 6 — Join the cluster again
+### Step 9 — Join the cluster again
 
-On the control plane, generate a fresh join config (requires `kubectl`/`kubeadm` for the
-cluster and the `kubeadm-join-config` binary this repo builds; see `Makefile`):
+On the control plane, generate a fresh join config (see `Makefile`):
 
 ```bash
-./scripts/join-config.sh        # writes config/kubeadm-join.storage.yaml (token + ca-hash are fresh)
+./scripts/join-config.sh   # writes config/kubeadm-join.storage.yaml (fresh token + ca-hash)
 ```
 
-Copy `config/kubeadm-join.storage.yaml` to the migrated node and join:
+Copy it to the node and join:
 
 ```bash
 sudo bash node.sh 'config/kubeadm-join.storage.yaml'
 ```
 
-Verify on the control plane that the node is back with the right label/taint and is
-`Ready`:
+Verify on the control plane that the node is back as `Ready` with the storage label/taint:
 
 ```bash
 kubectl get nodes -l node.mmontes.io/type=storage
 ```
 
-### Step 7 — Rook OSD migration
+### Step 10 — Rook OSD migration
 
-Precondition: the companion PR in `mmontes11/k8s-infrastructure`, which switches this node's
-device entry from `nvme0n1` to `nvme0n1p3` in
+Precondition: the companion PR in `mmontes11/k8s-infrastructure`, which switches
+`storage-2`'s device entry from `nvme0n1` to `nvme0n1p3` in
 `infrastructure/rook/rook-ceph-cluster/rook-ceph-cluster-helmrelease.yaml`, **is merged and
 applied by Flux** before this step.
 
-1. Remove the old OSD from the cluster (it ran on the now-wiped `nvme0n1` data area).
-   With `size(ceph_osd_pool) = 3` and the remaining OSDs healthy, this is safe:
+1. Remove the old OSD from the cluster (its data was wiped in Step 4):
 
    ```bash
-   kubectl -n storage exec deploy/rook-ceph-tools -- ceph osd out <old-osd-id>
-   kubectl -n storage exec deploy/rook-ceph-tools -- ceph osd rm <old-osd-id>
+   kubectl -n storage exec deploy/rook-ceph-tools -- ceph osd out 3
+   kubectl -n storage exec deploy/rook-ceph-tools -- ceph osd rm 3
    kubectl -n storage exec deploy/rook-ceph-tools -- ceph -s
    ```
 
@@ -190,30 +248,76 @@ applied by Flux** before this step.
    ```bash
    kubectl -n storage get pods -l app=rook-ceph-osd -o wide
    kubectl -n storage get osds
-   kubectl -n storage exec deploy/rook-ceph-tools -- ceph -s   # backfilling will show, converging to HEALTH_OK
+   kubectl -n storage exec deploy/rook-ceph-tools -- ceph -s   # backfilling will show, converging
    ```
 
-3. Wait for `HEALTH_OK` (all PGs `active+clean`) before touching the next node.
+3. Wait for convergence (all PGs `active+clean`) before migrating the next node.
+
+## Migrating the remaining nodes from the golden image
+
+`storage-1` and `storage-0` skip Steps 4–7: the golden image already contains the OS, the
+`128GiB`/`~1.7TiB` partition layout, and an empty raw `p3`. For each node:
+
+1. **Pre-flight**: per safety rule 2, the cluster must be converged with no missing OSDs.
+2. **Take the node out**: `kubectl drain <node> ...`, power off, keep its original SD card.
+3. **Stage**: fresh (or re-imaged) SD card per Step 3; attach the USB stick holding
+   `rpi5-nvme-golden.img`.
+4. **Restore the image onto the NVMe** (no rpi-imager, no partition surgery):
+
+   ```bash
+   sudo dd if=/dev/sdc/rpi5-nvme-golden.img of=/dev/nvme0n1 bs=4M status=progress
+   sync
+   ```
+
+5. **Per-node configuration**: the golden's `p1` still carries `storage-2`'s hostname and
+   address. Mount `p1` (FAT32) and edit `user-data` (hostname → the node name) and the
+   network config (→ the node's address) before its first boot. The filesystem on `p2` has
+   not consumed cloud-init yet, so the edited `user-data` applies on first boot:
+
+   ```bash
+   sudo mkdir /mnt/nvfat
+   sudo mount /dev/nvme0n1p1 /mnt/nvfat
+   # edit /mnt/nvfat/user-data and /mnt/nvfat/network-config
+   sudo umount /mnt/nvfat
+   ```
+
+6. **First NVMe boot**: remove the SD, power on, verify layout and hostname (Step 8 checks),
+   `sudo bash node-prepare.sh`, `sudo reboot`.
+7. **Rejoin** (Steps 9) with a fresh join config.
+8. **Rook** (Step 10): first make sure this node's own device entry in
+   `rook-ceph-cluster-helmrelease.yaml` is already `nvme0n1p3` (same one-line change, merged
+   and reconciled by Flux), then remove the old OSD id and let rook provision the new one
+   on `p3`. Wait for convergence before the next node.
+
+After the last node, all three device entries in the helmrelease are `nvme0n1p3`.
+
+## Rook re-provisioning cleanup
+
+If a newly created OSD ends up in a bad state and you want to start it over, wipe the rook
+partition and let rook re-provision it:
+
+```bash
+sudo bash scripts/cleanup-nvme.sh          # default target: /dev/nvme0n1p3
+```
+
+The script performs no checks — it zeroes the start of the target partition, discards it,
+re-probes, and removes `/var/lib/rook`. Pass a different device explicitly if the layout
+differs (e.g. the legacy whole-disk `nvme0n1` on a node that has not been migrated yet).
+You own the target argument.
 
 ## Rollback
 
-Before the node rejoins the cluster, data is on the two remaining OSDs at full
+Before the node rejoins the cluster, all data lives on the two remaining OSDs at full
 redundancy (`min_size` is satisfied with two of three OSDs). If the NVMe does not boot or
 anything goes wrong:
 
-1. Reinstall the **original SD card**, boot from it (NVMe out, or the firmware will prefer
-   the SD slot order configured on the Pi — remove the NVMe to be certain).
+1. Reinstall the **original SD card**, boot from it (remove the NVMe to be certain the
+   firmware does not try it first).
 2. The node boots as it did before; rejoin it with a fresh
    `config/kubeadm-join.storage.yaml` if it dropped out of the cluster.
 3. Rook still expects `nvme0n1`; if you already merged the `nvme0n1p3` change, revert that
-   entry (Flux will apply it) and the old OSD path is valid again. If you already ran
-   `ceph osd rm` in step 7, the old OSD id is gone from the cluster and the old NVMe's
-   data is abandoned — with two healthy OSDs the cluster remains consistent and fully
-   redundant, but re-plan the migration instead of hot-fixing.
-
-## Repeating for the other nodes
-
-Steps 1-7 are identical for `storage-0` and `storage-1`, with one difference in the end
-state: after the last node is migrated, all three device entries in
-`rook-ceph-cluster-helmrelease.yaml` become `nvme0n1p3`. Migrate in the order
-`storage-2` → `storage-1` → `storage-0`, and re-verify `HEALTH_OK` between each node.
+   entry (Flux will apply it) and the old whole-disk device is valid again — then wipe it
+   first with `scripts/cleanup-nvme.sh /dev/nvme0n1`, because the image/partition surgery
+   destroyed the old OSD data. If you already ran `ceph osd rm`, the old OSD id is gone
+   from the cluster: with two healthy OSDs the data is safe, but re-plan the migration
+   instead of hot-fixing.

--- a/docs/rpi5-nvme-storage-node.md
+++ b/docs/rpi5-nvme-storage-node.md
@@ -3,7 +3,8 @@
 Migrates a Raspberry Pi 5 worker/storage node from an SD-card root filesystem to the 2TB
 onboard NVMe module, so the OS lives on fast, durable storage while keeping a dedicated raw
 partition for the [rook-ceph](https://rook.io/) OSD. After the first node is migrated, its
-disk is captured as a byte-for-byte golden image and `dd`'d onto the remaining nodes.
+disk is captured as a compressed, byte-for-byte golden image pushed to a NAS over NFS, and
+piped (decompressed) onto the remaining nodes.
 
 No second Linux machine or USB NVMe enclosure is needed: a freshly flashed microSD card
 boots every node as the staging OS, and the NVMe image/partition work is done from there —
@@ -56,16 +57,18 @@ OS/OSD split, change it consistently in Steps 5 and 6 — nowhere else.
 
 - The node's own hardware: a **fresh ≥16GB microSD card** (the "staging OS" medium, reused
   per node) and the node's **original SD card** (kept untouched for rollback).
-- A small USB stick to hold the golden image: the disk is compressed on capture (`zstd`),
-  and a fresh OS install plus an empty partition compresses to a few hundred MB, so even an
-  8GB stick is plenty.
+- The **NAS** hosting the golden image: `10.0.0.50:/volume1/images`, an NFS export that is
+  readable and writable from any IP in `10.0.0.0/24`, mounted at `/mnt/nas` on the staging
+  OS. The disk is piped compressed (`zstd`) to it over the network at capture time, and the
+  compressed stream is piped back on restore — nothing but pipeline buffers touches local
+  disk, so the machines never need 2TB of free space.
 - The Ubuntu 24.04 preinstalled server image for Raspberry Pi
   (`ubuntu-24.04.4-preinstalled-server-arm64+raspi.img.xz` from the
   [Ubuntu releases](https://cdimage.ubuntu.com/releases/24.04/release/) archive, or via
   rpi-imager's built-in catalog).
 - rpi-imager on whatever machine you already use to image SD cards.
 - Once the staging OS is booted on the Pi: `sudo apt update && sudo apt install -y
-  rpi-imager parted gdisk zstd` (`e2fsprogs` ships with the base image).
+  rpi-imager parted gdisk zstd nfs-common` (`e2fsprogs` ships with the base image).
 
 ## Migrating the first node (storage-2) — produces the golden image
 
@@ -99,7 +102,7 @@ Image the fresh SD card with rpi-imager as you would any node (customize hostnam
 on, and SSH in.
 
 ```bash
-sudo apt update && sudo apt install -y rpi-imager parted gdisk zstd
+sudo apt update && sudo apt install -y rpi-imager parted gdisk zstd nfs-common
 lsblk -f      # the NVMe must be visible; it still holds the old OSD's data
 ```
 
@@ -173,21 +176,23 @@ sudo umount /mnt/nvfat
 
 ### Step 7 — Capture the golden image (before first boot, `p3` still raw)
 
-Back up the fully partitioned, not-yet-booted disk to the USB stick, compressed on the fly
-(the disk is mostly zeros — the raw `p3` and the unused portion of `p2` dominate, so the
-compression ratio is very high):
+Push the fully partitioned, not-yet-booted disk to the NAS over NFS as a pure pipe (the disk
+is mostly zeros — the raw `p3` and the unused portion of `p2` dominate, so the compression
+ratio is very high; at no point is a 2TB file written to local disk):
 
 ```bash
-# /dev/sdc = the USB stick — verify with lsblk so you never write to the NVMe
-sudo dd if=/dev/nvme0n1 bs=4M | sudo zstd -T0 -o /dev/sdc/rpi5-nvme-golden.img.zst
-sha256sum /dev/sdc/rpi5-nvme-golden.img.zst | tee /dev/sdc/rpi5-nvme-golden.img.zst.sha256
+sudo mkdir -p /mnt/nas
+sudo mount -t nfs 10.0.0.50:/volume1/images /mnt/nas
+
+# NVMe read → compress (all cores) → push over NFS
+sudo dd if=/dev/nvme0n1 bs=4M | sudo zstd -T0 -o /mnt/nas/rpi5-nvme-golden.img.zst
+sudo sha256sum /mnt/nas/rpi5-nvme-golden.img.zst | sudo tee /mnt/nas/rpi5-nvme-golden.img.zst.sha256
 sync
 ```
 
-The full-disk read is the dominant cost (a couple of minutes at NVMe speed); `zstd -T0`
-uses all cores. A fresh Ubuntu 24.04 install plus an empty partition compresses to roughly a
-few hundred MB, and the `.sha256` side file verifies it locally. Keep a copy of this image
-(and its checksum) safe — it sets up the remaining nodes.
+The full-disk read is the dominant cost (a couple of minutes at NVMe speed); what traverses
+the network is the compressed file, roughly a few hundred MB. The `.sha256` side file is
+what every restore verifies against before overwriting an NVMe.
 
 ### Step 8 — First NVMe boot
 
@@ -264,14 +269,19 @@ applied by Flux** before this step.
 
 1. **Pre-flight**: per safety rule 2, the cluster must be converged with no missing OSDs.
 2. **Take the node out**: `kubectl drain <node> ...`, power off, keep its original SD card.
-3. **Stage**: fresh (or re-imaged) SD card per Step 3; attach the USB stick holding
-   `rpi5-nvme-golden.img.zst`.
-4. **Verify and restore the image onto the NVMe** (no rpi-imager, no partition surgery;
-   decompression happens in the pipeline, nothing lands on disk as a 2TB image):
+3. **Stage**: fresh (or re-imaged) SD card per Step 3. No USB stick is needed — the image
+   comes over the network: the NFS export is writable/readable from any IP in `10.0.0.0/24`.
+4. **Pull, verify and restore the image onto the NVMe** (no rpi-imager, no partition
+   surgery; the compressed stream is pulled over NFS and decompressed in the pipeline
+   straight onto the NVMe — nothing lands on local disk as a 2TB image):
 
    ```bash
-   sha256sum -c /dev/sdc/rpi5-nvme-golden.img.zst.sha256
-   sudo zstd -dc /dev/sdc/rpi5-nvme-golden.img.zst | sudo dd of=/dev/nvme0n1 bs=4M status=progress
+   sudo mkdir -p /mnt/nas
+   sudo mount -t nfs 10.0.0.50:/volume1/images /mnt/nas
+   sudo sha256sum -c /mnt/nas/rpi5-nvme-golden.img.zst.sha256
+
+   # NFS read → decompress (all cores) → NVMe write
+   sudo zstd -dc /mnt/nas/rpi5-nvme-golden.img.zst | sudo dd of=/dev/nvme0n1 bs=4M status=progress
    sync
    ```
 

--- a/docs/rpi5-nvme-storage-node.md
+++ b/docs/rpi5-nvme-storage-node.md
@@ -56,16 +56,16 @@ OS/OSD split, change it consistently in Steps 5 and 6 — nowhere else.
 
 - The node's own hardware: a **fresh ≥16GB microSD card** (the "staging OS" medium, reused
   per node) and the node's **original SD card** (kept untouched for rollback).
-- A USB stick to hold the golden image: the `dd` copy is 2TB *apparent* size but with
-  `conv=sparse` it consumes only a few GB of real data (a fresh OS install plus an empty
-  partition), so a 16GB stick is plenty.
+- A small USB stick to hold the golden image: the disk is compressed on capture (`zstd`),
+  and a fresh OS install plus an empty partition compresses to a few hundred MB, so even an
+  8GB stick is plenty.
 - The Ubuntu 24.04 preinstalled server image for Raspberry Pi
   (`ubuntu-24.04.4-preinstalled-server-arm64+raspi.img.xz` from the
   [Ubuntu releases](https://cdimage.ubuntu.com/releases/24.04/release/) archive, or via
   rpi-imager's built-in catalog).
 - rpi-imager on whatever machine you already use to image SD cards.
 - Once the staging OS is booted on the Pi: `sudo apt update && sudo apt install -y
-  rpi-imager parted gdisk` (`e2fsprogs` ships with the base image).
+  rpi-imager parted gdisk zstd` (`e2fsprogs` ships with the base image).
 
 ## Migrating the first node (storage-2) — produces the golden image
 
@@ -99,7 +99,7 @@ Image the fresh SD card with rpi-imager as you would any node (customize hostnam
 on, and SSH in.
 
 ```bash
-sudo apt update && sudo apt install -y rpi-imager parted gdisk
+sudo apt update && sudo apt install -y rpi-imager parted gdisk zstd
 lsblk -f      # the NVMe must be visible; it still holds the old OSD's data
 ```
 
@@ -173,17 +173,21 @@ sudo umount /mnt/nvfat
 
 ### Step 7 — Capture the golden image (before first boot, `p3` still raw)
 
-Back up the fully partitioned, not-yet-booted disk to the USB stick:
+Back up the fully partitioned, not-yet-booted disk to the USB stick, compressed on the fly
+(the disk is mostly zeros — the raw `p3` and the unused portion of `p2` dominate, so the
+compression ratio is very high):
 
 ```bash
 # /dev/sdc = the USB stick — verify with lsblk so you never write to the NVMe
-sudo dd if=/dev/nvme0n1 of=/dev/sdc/rpi5-nvme-golden.img bs=4M conv=sparse status=progress
+sudo dd if=/dev/nvme0n1 bs=4M | sudo zstd -T0 -o /dev/sdc/rpi5-nvme-golden.img.zst
+sha256sum /dev/sdc/rpi5-nvme-golden.img.zst | tee /dev/sdc/rpi5-nvme-golden.img.zst.sha256
 sync
 ```
 
-The file is 2TB in apparent size but `conv=sparse` stores only the non-zero bytes (a few GB
-for a fresh install); the read of the empty partition dominates the runtime (order of an
-hour). Keep a copy of this image safe — it sets up the remaining nodes.
+The full-disk read is the dominant cost (a couple of minutes at NVMe speed); `zstd -T0`
+uses all cores. A fresh Ubuntu 24.04 install plus an empty partition compresses to roughly a
+few hundred MB, and the `.sha256` side file verifies it locally. Keep a copy of this image
+(and its checksum) safe — it sets up the remaining nodes.
 
 ### Step 8 — First NVMe boot
 
@@ -261,11 +265,13 @@ applied by Flux** before this step.
 1. **Pre-flight**: per safety rule 2, the cluster must be converged with no missing OSDs.
 2. **Take the node out**: `kubectl drain <node> ...`, power off, keep its original SD card.
 3. **Stage**: fresh (or re-imaged) SD card per Step 3; attach the USB stick holding
-   `rpi5-nvme-golden.img`.
-4. **Restore the image onto the NVMe** (no rpi-imager, no partition surgery):
+   `rpi5-nvme-golden.img.zst`.
+4. **Verify and restore the image onto the NVMe** (no rpi-imager, no partition surgery;
+   decompression happens in the pipeline, nothing lands on disk as a 2TB image):
 
    ```bash
-   sudo dd if=/dev/sdc/rpi5-nvme-golden.img of=/dev/nvme0n1 bs=4M status=progress
+   sha256sum -c /dev/sdc/rpi5-nvme-golden.img.zst.sha256
+   sudo zstd -dc /dev/sdc/rpi5-nvme-golden.img.zst | sudo dd of=/dev/nvme0n1 bs=4M status=progress
    sync
    ```
 

--- a/docs/rpi5-nvme-storage-node.md
+++ b/docs/rpi5-nvme-storage-node.md
@@ -1,0 +1,219 @@
+# Raspberry Pi 5 storage node: SD card to NVMe migration
+
+Migrates a Raspberry Pi 5 worker/storage node from an SD-card root filesystem to the onboard
+NVMe module, so the OS lives on fast, durable storage while keeping a dedicated raw
+partition for the [rook-ceph](https://rook.io/) OSD.
+
+Reference: [Install Ubuntu on the NVMe of a Raspberry Pi 5](https://wolfpaulus.com/rp5-ubuntu-cli/).
+
+## Target layout
+
+A 128GB NVMe module, 3 partitions (the RPi5 firmware requires a FAT32 `/boot/firmware`
+partition, hence one more partition than a plain Linux install):
+
+| Partition | Filesystem | Size   | Mount  |
+|-----------|------------|--------|--------|
+| `nvme0n1p1` | fat32    | 512MiB | `/boot/firmware` |
+| `nvme0n1p2` | ext4     | ~124GiB | `/` |
+| `nvme0n1p3` | (raw, unformatted) | remainder (~4GiB) | none — claimed by rook-ceph |
+
+Rook consumes `nvme0n1p3`. The OS never sees `nvme0n1p3`; rook takes exclusive control of
+it, exactly as it does today with the whole-disk `nvme0n1` configuration on the other nodes.
+
+## Safety rules (read first)
+
+1. **One node at a time.** Never migrate two storage nodes in parallel.
+2. **Ceph must be `HEALTH_OK` before you start.** Check on the control plane:
+   ```bash
+   kubectl -n storage exec deploy/rook-ceph-tools -- ceph -s
+   ```
+   If there is an in-flight backfill (e.g. `active+undersized+degraded+...+backfilling`
+   PGs after a previous re-image), wait until all PGs are `active+clean`. Migrating a node
+   while the cluster is already degraded compounds the degraded window and can leave the
+   cluster in a state it cannot recover.
+3. **Keep the original SD card until the node is fully back in service** (see
+   [Rollback](#rollback). It is your safety net and your spare for the next node.
+4. **Merge the rook device-config PR before the migrated node rejoins the cluster** (see
+   [Step 7](#step-7-rook-osd-migration)). Otherwise rook still expects the old
+   whole-disk `nvme0n1` and will never see `nvme0n1p3`.
+5. The OS partition is sized to leave only ~4GiB for the OSD. Raise `OS_END` (and lower the
+   OSD) or lower it (and grow the OSD) to taste — but decide before flashing, the numbers
+   below are used consistently.
+
+## Tools and hardware
+
+- A second Linux machine (the "helper") with a USB NVMe enclosure, plus: `rpi-imager`,
+  `parted`, `sgdisk`, `e2fsck`, `resize2fs` (the `ubuntu-image` + `parted` +
+  `dosfstools` + `e2fsprogs` packages).
+- Ubuntu 24.04 preinstalled server image for Raspberry Pi
+  (`ubuntu-24.04.4-preinstalled-server-arm64+raspi.img.xz` from the
+  [Ubuntu releases](https://cdimage.ubuntu.com/releases/24.04/release/) archive, or via
+  rpi-imager's built-in catalog).
+- A USB-serial console for the Pi (the storage nodes have no display; you need the console
+  to boot into a fresh install and set the hostname/network).
+
+## Procedure
+
+### Step 1 — Pre-flight on the control plane
+
+```bash
+kubectl -n storage exec deploy/rook-ceph-tools -- ceph -s
+kubectl get nodes -l node.mmontes.io/type=storage
+kubectl -n storage get pods -l app=rook-ceph-osd -o wide    # note which osd pod runs on the target node
+```
+
+Note the OSD id of the target node (e.g. `osd-3` on `storage-2`). You need it for
+[Step 7](#step-7-rook-osd-migration). Ceph must say `HEALTH_OK` — see safety rules.
+
+### Step 2 — Take the node out of the cluster
+
+On the control plane:
+
+```bash
+kubectl drain <node> --ignore-daemonsets --delete-emptydir-data
+```
+
+Then power the Pi off and remove its NVMe module into the USB enclosure on the helper.
+
+### Step 3 — Flash a fresh OS onto the NVMe
+
+From the helper:
+
+```bash
+# Identify the raw device (lsblk). Assume /dev/nvme0n1 on the helper for the commands below.
+sudo rpi-imager
+```
+
+In rpi-imager: OS → *Ubuntu 24.04 (preinstalled, Raspberry Pi)*, Storage → the NVMe device,
+flash. This writes a two-partition GPT: `p1` FAT32 (boot) and `p2` ext4 (root, sized for
+the image, not for the disk).
+
+### Step 4 — Offline partition surgery (helper, NVMe not booted)
+
+Goal: shrink/fit `p2` to end at `124GiB`, grow its ext4 to `120G`, and create the raw
+rook partition `p3` from what is left. Everything here is safe because **the disk is not
+being used by any running system**.
+
+```bash
+DEV=/dev/nvme0n1    # the flashed NVMe on the helper — verify with lsblk
+
+sudo parted -s $DEV print                       # sanity check: GPT, p1 fat, p2 ext4
+
+# Fit p2: extend (or trim) its end boundary to 124GiB from the start of the disk.
+sudo parted -s $DEV resizepart 2 124GiB
+
+# Check/ext4 before touching it (-f forces, -y answers yes to cleanups):
+sudo e2fsck -f -y ${DEV}p2
+
+# Set the ext4 to 120G. resize2fs both grows and shrinks to the requested size, so this
+# one command covers whether p2 was image-sized or already expanded to the full disk.
+sudo resize2fs ${DEV}p2 120G
+
+# Create the rook partition from the remainder of the disk. Do NOT format it:
+sudo parted -s $DEV mkpart rook 124GiB 100%
+sudo sgdisk -t 3:8300 $DEV                      # explicit Linux filesystem partition type
+
+# Verify:
+sudo parted -s $DEV print
+sudo blkid ${DEV}p2 ${DEV}p3                    # p2 must show ext4; p3 must show NOTHING
+```
+
+`blkid` printing nothing for `p3` is required: rook provisions an unformatted device
+itself. If `blkid` reports a filesystem on `p3`, delete and recreate the partition.
+
+### Step 5 — First NVMe boot on the Pi
+
+Reinstall the NVMe, **leave the SD card out**, power on, and follow the console:
+
+- Set the hostname (e.g. `storage-0`) and the static IP matching your inventory.
+- The preinstalled image runs cloud-init on first boot. After login, verify the layout is
+  intact (cloud-init must not have expanded `p2` beyond the boundary):
+
+  ```bash
+  lsblk /dev/nvme0n1
+  df -h /
+  blkid /dev/nvme0n1p3     # must print nothing
+  ```
+
+  `p2` must be ~124G and mounted on `/`, and `p3` unmounted. If `p2` grew over the
+  boundary (p3 gone or shrunk), stop: power off, redo [Step 4](#step-4--offline-partition-surgery-helper-nvme-not-booted)
+  on the helper. Booting from the original SD card is the fallback (see Rollback).
+
+Then run the standard node preparation (works unchanged, `cmdline.txt` now lives on the
+NVMe `p1`):
+
+```bash
+sudo bash node-prepare.sh
+sudo reboot
+```
+
+### Step 6 — Join the cluster again
+
+On the control plane, generate a fresh join config (requires `kubectl`/`kubeadm` for the
+cluster and the `kubeadm-join-config` binary this repo builds; see `Makefile`):
+
+```bash
+./scripts/join-config.sh        # writes config/kubeadm-join.storage.yaml (token + ca-hash are fresh)
+```
+
+Copy `config/kubeadm-join.storage.yaml` to the migrated node and join:
+
+```bash
+sudo bash node.sh 'config/kubeadm-join.storage.yaml'
+```
+
+Verify on the control plane that the node is back with the right label/taint and is
+`Ready`:
+
+```bash
+kubectl get nodes -l node.mmontes.io/type=storage
+```
+
+### Step 7 — Rook OSD migration
+
+Precondition: the companion PR in `mmontes11/k8s-infrastructure`, which switches this node's
+device entry from `nvme0n1` to `nvme0n1p3` in
+`infrastructure/rook/rook-ceph-cluster/rook-ceph-cluster-helmrelease.yaml`, **is merged and
+applied by Flux** before this step.
+
+1. Remove the old OSD from the cluster (it ran on the now-wiped `nvme0n1` data area).
+   With `size(ceph_osd_pool) = 3` and the remaining OSDs healthy, this is safe:
+
+   ```bash
+   kubectl -n storage exec deploy/rook-ceph-tools -- ceph osd out <old-osd-id>
+   kubectl -n storage exec deploy/rook-ceph-tools -- ceph osd rm <old-osd-id>
+   kubectl -n storage exec deploy/rook-ceph-tools -- ceph -s
+   ```
+
+2. Rook discovers the raw `nvme0n1p3` and creates a new OSD on it. Watch it come up:
+
+   ```bash
+   kubectl -n storage get pods -l app=rook-ceph-osd -o wide
+   kubectl -n storage get osds
+   kubectl -n storage exec deploy/rook-ceph-tools -- ceph -s   # backfilling will show, converging to HEALTH_OK
+   ```
+
+3. Wait for `HEALTH_OK` (all PGs `active+clean`) before touching the next node.
+
+## Rollback
+
+Before the node rejoins the cluster, data is on the two remaining OSDs at full
+redundancy (`min_size` is satisfied with two of three OSDs). If the NVMe does not boot or
+anything goes wrong:
+
+1. Reinstall the **original SD card**, boot from it (NVMe out, or the firmware will prefer
+   the SD slot order configured on the Pi — remove the NVMe to be certain).
+2. The node boots as it did before; rejoin it with a fresh
+   `config/kubeadm-join.storage.yaml` if it dropped out of the cluster.
+3. Rook still expects `nvme0n1`; if you already merged the `nvme0n1p3` change, revert that
+   entry (Flux will apply it) and the old OSD path is valid again. If you already ran
+   `ceph osd rm` in step 7, the old OSD id is gone from the cluster and the old NVMe's
+   data is abandoned — with two healthy OSDs the cluster remains consistent and fully
+   redundant, but re-plan the migration instead of hot-fixing.
+
+## Repeating for the other nodes
+
+Steps 1-7 are identical for `storage-0` and `storage-1`, with one difference in the end
+state: after the last node is migrated, all three device entries in
+`rook-ceph-cluster-helmrelease.yaml` become `nvme0n1p3`. Migrate in the order
+`storage-2` → `storage-1` → `storage-0`, and re-verify `HEALTH_OK` between each node.

--- a/scripts/cleanup-nvme.sh
+++ b/scripts/cleanup-nvme.sh
@@ -4,71 +4,25 @@
 # https://rook.io/docs/rook/latest-release/Getting-Started/ceph-teardown/
 # https://rook.io/docs/rook/latest-release/Getting-Started/Prerequisites/prerequisites/#ceph-prerequisites
 #
-# Two supported disk layouts:
-# - Legacy: the whole device is a rook device (OS runs from an SD card or other disk).
-#   The entire disk is zapped, as before.
-# - k8s-bootstrap RPi5 NVMe layout (see docs/rpi5-nvme-storage-node.md): the OS runs from
-#   a partition of the device (e.g. nvme0n1p2) and rook owns a dedicated partition
-#   (e.g. nvme0n1p3). In that case only the rook partition may be wiped; the disk and
-#   the OS partitions are never touched.
+# Wipe the rook-ceph partition of the RPi5 NVMe layout
+# (see docs/rpi5-nvme-storage-node.md): /dev/nvme0n1p3 by default.
+# Pass another partition explicitly if the layout differs (e.g. the legacy
+# whole-disk /dev/nvme0n1 on a node that has not been migrated yet).
+# No checks are performed: the caller is responsible for providing the
+# correct target device.
 
 set -euo pipefail
 
-DISK="${1:-/dev/nvme0n1}"
-
-[ -b "$DISK" ] || { echo "error: $DISK is not a block device" >&2; exit 1; }
-
-# Does the OS run from a partition of $DISK?
-ROOT_DEV=$(findmnt -no SOURCE /)
-case "$ROOT_DEV" in
-  "$DISK"p*) OS_ON_DISK=yes ;;
-  *)         OS_ON_DISK=no ;;
-esac
-
-if [ "$OS_ON_DISK" = "yes" ]; then
-    # Identify the rook partition: an unmounted partition of $DISK that carries no
-    # filesystem (blkid reports nothing) or only stale LVM metadata. The root
-    # partition is always excluded.
-    ROOK_PART=""
-    for part in ${DISK}p*; do
-        [ -b "$part" ] || continue
-        [ "$part" = "$ROOT_DEV" ] && continue
-        [ -n "$(findmnt -rn -n -o TARGET --source "$part")" ] && continue
-        part_type=$(blkid -o value -s TYPE "$part" 2>/dev/null | head -n1 || true)
-        if [ -z "$part_type" ] || [ "$part_type" = "LVM2_member" ]; then
-            if [ -n "$ROOK_PART" ]; then
-                echo "error: multiple unmounted candidate partitions on $DISK: $ROOK_PART $part" >&2
-                exit 1
-            fi
-            ROOK_PART=$part
-        fi
-    done
-
-    if [ -z "$ROOK_PART" ]; then
-        echo "error: no unmounted rook partition found on $DISK (OS runs from $ROOT_DEV); refusing to continue" >&2
-        exit 1
-    fi
-
-    TARGET="$ROOK_PART"
-    echo "OS runs from $ROOT_DEV on $DISK; wiping only $TARGET"
-else
-    TARGET="$DISK"
-    echo "OS runs from $ROOT_DEV, not from $DISK; zapping whole disk"
-fi
-
-if [ "$OS_ON_DISK" = "no" ]; then
-    # Zap the disk to a fresh, usable state (zap-all is important, b/c MBR has to be clean)
-    sgdisk --zap-all "$DISK" >/dev/null
-fi
+PART="${1:-/dev/nvme0n1p3}"
 
 # Wipe a large portion of the beginning of the target to remove LVM metadata that may be present
-dd if=/dev/zero of="$TARGET" bs=1M count=100 oflag=direct,dsync status=none
+dd if=/dev/zero of="$PART" bs=1M count=100 oflag=direct,dsync status=none
 
 # SSDs may be better cleaned with blkdiscard instead of dd
-blkdiscard "$TARGET"
+blkdiscard "$PART"
 
 # Inform the OS of partition table changes
-partprobe "$DISK"
+partprobe "${PART%p*}"
 
 # Remove rook directory
 rm -rf /var/lib/rook

--- a/scripts/cleanup-nvme.sh
+++ b/scripts/cleanup-nvme.sh
@@ -3,20 +3,72 @@
 # see:
 # https://rook.io/docs/rook/latest-release/Getting-Started/ceph-teardown/
 # https://rook.io/docs/rook/latest-release/Getting-Started/Prerequisites/prerequisites/#ceph-prerequisites
+#
+# Two supported disk layouts:
+# - Legacy: the whole device is a rook device (OS runs from an SD card or other disk).
+#   The entire disk is zapped, as before.
+# - k8s-bootstrap RPi5 NVMe layout (see docs/rpi5-nvme-storage-node.md): the OS runs from
+#   a partition of the device (e.g. nvme0n1p2) and rook owns a dedicated partition
+#   (e.g. nvme0n1p3). In that case only the rook partition may be wiped; the disk and
+#   the OS partitions are never touched.
 
-DISK="/dev/nvme0n1"
+set -euo pipefail
 
-# Zap the disk to a fresh, usable state (zap-all is important, b/c MBR has to be clean)
-sgdisk --zap-all $DISK
+DISK="${1:-/dev/nvme0n1}"
 
-# Wipe a large portion of the beginning of the disk to remove more LVM metadata that may be present
-dd if=/dev/zero of="$DISK" bs=1M count=100 oflag=direct,dsync
+[ -b "$DISK" ] || { echo "error: $DISK is not a block device" >&2; exit 1; }
+
+# Does the OS run from a partition of $DISK?
+ROOT_DEV=$(findmnt -no SOURCE /)
+case "$ROOT_DEV" in
+  "$DISK"p*) OS_ON_DISK=yes ;;
+  *)         OS_ON_DISK=no ;;
+esac
+
+if [ "$OS_ON_DISK" = "yes" ]; then
+    # Identify the rook partition: an unmounted partition of $DISK that carries no
+    # filesystem (blkid reports nothing) or only stale LVM metadata. The root
+    # partition is always excluded.
+    ROOK_PART=""
+    for part in ${DISK}p*; do
+        [ -b "$part" ] || continue
+        [ "$part" = "$ROOT_DEV" ] && continue
+        [ -n "$(findmnt -rn -n -o TARGET --source "$part")" ] && continue
+        part_type=$(blkid -o value -s TYPE "$part" 2>/dev/null | head -n1 || true)
+        if [ -z "$part_type" ] || [ "$part_type" = "LVM2_member" ]; then
+            if [ -n "$ROOK_PART" ]; then
+                echo "error: multiple unmounted candidate partitions on $DISK: $ROOK_PART $part" >&2
+                exit 1
+            fi
+            ROOK_PART=$part
+        fi
+    done
+
+    if [ -z "$ROOK_PART" ]; then
+        echo "error: no unmounted rook partition found on $DISK (OS runs from $ROOT_DEV); refusing to continue" >&2
+        exit 1
+    fi
+
+    TARGET="$ROOK_PART"
+    echo "OS runs from $ROOT_DEV on $DISK; wiping only $TARGET"
+else
+    TARGET="$DISK"
+    echo "OS runs from $ROOT_DEV, not from $DISK; zapping whole disk"
+fi
+
+if [ "$OS_ON_DISK" = "no" ]; then
+    # Zap the disk to a fresh, usable state (zap-all is important, b/c MBR has to be clean)
+    sgdisk --zap-all "$DISK" >/dev/null
+fi
+
+# Wipe a large portion of the beginning of the target to remove LVM metadata that may be present
+dd if=/dev/zero of="$TARGET" bs=1M count=100 oflag=direct,dsync status=none
 
 # SSDs may be better cleaned with blkdiscard instead of dd
-blkdiscard $DISK
+blkdiscard "$TARGET"
 
 # Inform the OS of partition table changes
-partprobe $DISK
+partprobe "$DISK"
 
 # Remove rook directory
 rm -rf /var/lib/rook


### PR DESCRIPTION
Close LAB-60

## Summary

Adds the runbook and supporting tooling to migrate the Raspberry Pi 5 storage nodes from an SD-card root filesystem to the onboard 2TB NVMe, keeping a dedicated raw partition for the rook-ceph OSD. No second machine is needed: a freshly flashed microSD card boots each node as a staging OS, and the NVMe imaging/partition work happens from there (same flow as the reference tutorial). The first migrated node produces a compressed (`zstd`) golden image pushed to the NAS (`10.0.0.50:/volume1/images`, NFS) as a pure pipe, and the remaining nodes restore it with decompression in the pipeline.

**Target NVMe layout** (2TB module):

| Partition | Filesystem | Size | Mount |
|---|---|---|---|
| `nvme0n1p1` | fat32 | 512MiB | `/boot/firmware` |
| `nvme0n1p2` | ext4 | ends at 128GiB (fs 124G) | `/` |
| `nvme0n1p3` | (raw) | ~1.7TiB remainder | rook-ceph |

The RPi5 firmware requires the FAT32 boot partition, hence three partitions rather than two.

## Changes

- `docs/rpi5-nvme-storage-node.md` — full migration runbook: safety rules (one node at a time; one down OSD tolerated, stacked degradations prohibited — the cluster must be converged before starting), staging OS from a fresh SD card, NVMe write via `rpi-imager --cli`, offline partition surgery, per-node `user-data`/networking copied into `p1` (headless via SSH), compressed `dd | zstd` golden-image capture **pushed over NFS to the NAS** before first boot (with a `sha256` side file, verified on every restore), first-boot verification, rejoining with a fresh `config/kubeadm-join.storage.yaml`, rook OSD migration (`ceph osd out` / `ceph osd rm` → new OSD on `nvme0n1p3`), and a `zstd -dc | dd` pull-and-restore procedure for `storage-1`/`storage-0` (edit hostname/IP in the clone's `p1` before first boot). All image transfers are pure Unix pipes, so no machine ever needs 2TB of disk space.
- `scripts/cleanup-nvme.sh` — wipes the rook partition (default `/dev/nvme0n1p3`), no checks: zero the start, `blkdiscard`, `partprobe`, remove `/var/lib/rook`. The caller provides the target device (e.g. the legacy whole-disk `nvme0n1` on a not-yet-migrated node).
- `README.md` — pointer to the runbook.

## Companion PR

The rook device-config change for `storage-2` (`nvme0n1` → `nvme0n1p3`) lands in `mmontes11/k8s-infrastructure` and must be merged **before** the migrated node rejoins the cluster; the runbook calls this out as a precondition of the OSD migration step.

## Validation

- `bash -n` on the script; flow reviewed against the reference tutorial. No CI runs on shell scripts in this repo (Go lint/build/test only).