### PR TITLE
Add rpi5-nvme-storage-node runbook dependencies to apt.sh

### DIFF
--- a/scripts/apt.sh
+++ b/scripts/apt.sh
@@ -14,6 +14,7 @@ apt install \
   conntrack \
   curl \
   gawk \
+  gdisk \
   git \
   gnupg \
   gpg \
@@ -29,11 +30,14 @@ apt install \
   nfs-common \
   openssh-server \
   openssl \
+  parted \
+  rpi-imager \
   sed \
   socat \
   systemd \
   vim \
   wget \
+  zstd \
   -y
 
 apt autoremove -y

--- a/scripts/storage.sh
+++ b/scripts/storage.sh
@@ -5,19 +5,7 @@ set -euo pipefail
 source ./scripts/lib.sh
 
 # see:
-# docs/rpi5-nvme-storage-node.md
 # https://github.com/rook/rook/issues/1312
-
-# dependencies for the RPi5 NVMe storage node runbook
-# (nfs-common and wget are already installed by scripts/apt.sh;
-# e2fsprogs and the coreutils/sysfs tools ship with the base image)
-apt update
-apt install \
-  gdisk \
-  parted \
-  rpi-imager \
-  zstd \
-  -y
 
 # kernel modules
 cat <<EOF | tee /etc/modules-load.d/rook-ceph.conf

--- a/scripts/storage.sh
+++ b/scripts/storage.sh
@@ -5,7 +5,19 @@ set -euo pipefail
 source ./scripts/lib.sh
 
 # see:
+# docs/rpi5-nvme-storage-node.md
 # https://github.com/rook/rook/issues/1312
+
+# dependencies for the RPi5 NVMe storage node runbook
+# (nfs-common and wget are already installed by scripts/apt.sh;
+# e2fsprogs and the coreutils/sysfs tools ship with the base image)
+apt update
+apt install \
+  gdisk \
+  parted \
+  rpi-imager \
+  zstd \
+  -y
 
 # kernel modules
 cat <<EOF | tee /etc/modules-load.d/rook-ceph.conf


### PR DESCRIPTION
## Summary

Adds the apt dependencies required by the RPi5 NVMe storage node runbook (`docs/rpi5-nvme-storage-node.md`) to the central `scripts/apt.sh` install list, so every node provisioned via `node.sh` / `control-plane.sh` has the tooling the runbook relies on.

Added to the `apt install` list (alphabetical):

- `gdisk`
- `parted`
- `rpi-imager`
- `zstd`

## What is intentionally NOT added

- `nfs-common` and `wget` — already in the `scripts/apt.sh` list.
- `e2fsprogs` — ships with the Ubuntu 24.04 base image (the runbook itself does not install it; it provides the e2fsck/resize2fs used during partition surgery).
- `dd`, `sha256sum`, `lsblk`, `blkid`, `hostnamectl`, `e2fsck`, `resize2fs` — standard coreutils/sysfs/util-linux tools present in the base system.

`scripts/storage.sh` is unchanged (it only configures the Rook Ceph kernel modules). Verified against `mmontes11/k8s-tooling`: its scripts only install binary tooling (kubectl, helm, rclone, kopia, …) and no apt packages, so there is no overlap there.

## Verification

- `bash -n scripts/apt.sh` and `bash -n scripts/storage.sh` pass.
- CI has no shell gate (Go-only: golangci-lint, build, test); no Go files were touched.

Closes LAB-90